### PR TITLE
Retain original filename as imported profile name

### DIFF
--- a/Passepartout/App/Views/AddHostViewModel.swift
+++ b/Passepartout/App/Views/AddHostViewModel.swift
@@ -49,7 +49,7 @@ extension AddHostView {
                 return
             }
             isNamePreset = true
-            profileName = url.normalizedFilename
+            profileName = url.filename
         }
 
         @MainActor

--- a/PassepartoutLibrary/Sources/PassepartoutUtils/Utils/Utils+URL.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutUtils/Utils/Utils+URL.swift
@@ -32,11 +32,8 @@ import AppKit
 #endif
 
 extension URL {
-    private static let illegalCharacterFallback = "_"
-    
-    public var normalizedFilename: String {
-        let filename = deletingPathExtension().lastPathComponent
-        return filename.components(separatedBy: CharacterSet.filename.inverted).joined(separator: URL.illegalCharacterFallback)
+    public var filename: String {
+        deletingPathExtension().lastPathComponent
     }
     
     @discardableResult


### PR DESCRIPTION
URL "Normalization" is an old drag of when profiles were stored in the filesystem with their descriptive name, requiring some illegal characters to be replaced. It's not been the case for a long while.