### PR TITLE
Freeze release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,14 +169,10 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_push_gpgsign: false
-      - name: Pull metadata updates
-        run: |
-          git pull --no-tags origin $GITHUB_REF_NAME
-          git submodule update --recursive
       - name: Tag release
         run: |
           scripts/ci/commit-release.sh $TAG_NAME
-          git push && git push --tags
+          git push --tags
       - name: Assemble notes
         run: |
           scripts/ci/release-notes.sh $TAG_NAME >$RELEASE_NOTES

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - '.beta-*'
       - '**/*.md'
+      - '**/*.sh'
+      - '**/*.yml'
       - 'Passepartout/App/fastlane/**'
 
 jobs:

--- a/scripts/merge-released-version.sh
+++ b/scripts/merge-released-version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+VERSION_PREV=$1
+if [[ -z $VERSION_PREV ]]; then
+    echo "Released version number required"
+    exit 1
+fi
+
+RELEASE_BASE=`git merge-base master "v$VERSION_PREV" 2>>/dev/null`
+if [[ $? != 0 ]]; then
+    echo "Version does not exist"
+    exit 1
+fi
+
+COMMITS_COUNT=`git rev-list --count $RELEASE_BASE..v$VERSION_PREV`
+if [[ $COMMITS_COUNT == 0 ]]; then
+    echo "Version is already merged"
+    exit 1
+fi
+
+if ! git checkout -b "merge/v$VERSION_PREV" master; then
+    echo "Could not create merge branch"
+    exit 1
+fi
+if ! git cherry-pick $RELEASE_BASE.."v$VERSION_PREV"; then
+    echo "Automatic cherry-picking has failed"
+    exit 1
+fi

--- a/scripts/start-new-version.sh
+++ b/scripts/start-new-version.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
-VERSION=$1
-
-if [[ -z $VERSION ]]; then
-    echo "Version number required"
+VERSION_NEXT=$2
+if [[ -z $VERSION_NEXT ]]; then
+    echo "New version number required"
     exit 1
 fi
 
 CHANGELOG_GLOB="CHANGELOG.md"
-
-ci/set-version.sh $VERSION
+ci/set-version.sh $VERSION_NEXT
 sed -i '' -E "s/(^and this project adheres.*$)/\1\n\n## Unreleased/" $CHANGELOG_GLOB
-
 git add *.plist $CHANGELOG_GLOB
 git commit -m "Bump version"


### PR DESCRIPTION
Automate import of pending version hotfixes without blocking development on master.

Given a linear history in master:

```
master

A - B - C - G - H - I - ... (active development)
         \
          D - E - F (v3.0.0)
```

add a script that, later in master, is able to automate cherry-picking of v3.0.0 commits.

The script:

1. Looks up the merge base of v3.0.0 (C)
2. Infers all the commits/hotfixes that led up to the v3.0.0 release (D, E, F)
3. Creates a merge branch from master
4. Cherry-picks all commits from 2

Step 4 may rarely generate conflicts. However, the faster the release, the less likely.

At this point, the merge branch merge/v3.0.0 looks like the following:

```
master

A - B - C - G - H - I - ... (active development)
         \
          D - E - F (v3.0.0)

merge/v3.0.0

A - B - C - G - H - I - D' -  E' - F' (active development)
```
