### PR TITLE
Move refund detection inside ProductManager

### DIFF
--- a/Passepartout/App/Context/AppContext.swift
+++ b/Passepartout/App/Context/AppContext.swift
@@ -70,7 +70,16 @@ class AppContext {
                     pp_log.info("VPN successful connection, report to Reviewer")
                     self.reviewer.reportEvent()
                 }
-        }.store(in: &cancellables)
+            }.store(in: &cancellables)
+
+        productManager.didRefundProducts
+            .receive(on: DispatchQueue.main)
+            .sink {
+                Task {
+                    pp_log.info("Refunds detected, uninstalling VPN profile")
+                    await coreContext.vpnManager.uninstall()
+                }
+            }.store(in: &cancellables)
     }
     
     // eligibility: ignore network settings if ineligible

--- a/Passepartout/App/Views/OrganizerView+Scene.swift
+++ b/Passepartout/App/Views/OrganizerView+Scene.swift
@@ -34,8 +34,6 @@ extension OrganizerView {
         
         @ObservedObject private var vpnManager: VPNManager
         
-        @ObservedObject private var productManager: ProductManager
-        
         @Binding private var alertType: AlertType?
         
         @Binding private var didHandleSubreddit: Bool
@@ -45,7 +43,6 @@ extension OrganizerView {
         init(alertType: Binding<AlertType?>, didHandleSubreddit: Binding<Bool>) {
             profileManager = .shared
             vpnManager = .shared
-            productManager = .shared
             _alertType = alertType
             _didHandleSubreddit = didHandleSubreddit
         }
@@ -85,16 +82,6 @@ extension OrganizerView {
 
         private func onScenePhase(_ phase: ScenePhase) {
             switch phase {
-            case .inactive:
-                productManager.snapshotRefunds()
-
-            case .active:
-                if productManager.hasNewRefunds() {
-                    Task { @MainActor in
-                        await vpnManager.uninstall()
-                    }
-                }
-
             case .background:
                 persist()
                 #if targetEnvironment(macCatalyst)


### PR DESCRIPTION
Revisit resolution of #238, because checking on scene active/inactive is fragile. Instead, react to IAP events.