### PR TITLE
Resolve issues with lock screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Option to lock app when entering background (iOS). [#270](https://github.com/passepartoutvpn/passepartout-apple/pull/270)
+- Option to lock app when entering background (iOS). [#270](https://github.com/passepartoutvpn/passepartout-apple/pull/270), [#271](https://github.com/passepartoutvpn/passepartout-apple/pull/271), [#273](https://github.com/passepartoutvpn/passepartout-apple/pull/273)
 - 3D Touch items (iOS). [#267](https://github.com/passepartoutvpn/passepartout-apple/pull/267)
 - Ukranian translations (Dmitry Chirkin). [#243](https://github.com/passepartoutvpn/passepartout-apple/pull/243)
 - Restore DNS "Domain" setting. [#260](https://github.com/passepartoutvpn/passepartout-apple/pull/260)

--- a/Passepartout/App/Constants/Theme.swift
+++ b/Passepartout/App/Constants/Theme.swift
@@ -57,6 +57,9 @@ extension View {
 extension View {
     func themeGlobal() -> some View {
         themeNavigationViewStyle()
+            #if !targetEnvironment(macCatalyst)
+            .themeLockScreen()
+            #endif
             .themeTint()
             .listStyle(themeListStyleValue())
             .toggleStyle(themeToggleStyleValue())
@@ -487,6 +490,18 @@ extension View {
         } else {
             EmptyView()
         }
+    }
+
+    func themeLockScreen() -> some View {
+        @AppStorage(AppPreference.locksInBackground.rawValue) var locksInBackground = false
+        return LockableView(
+            reason: L10n.Global.Messages.unlockApp,
+            locksInBackground: $locksInBackground,
+            content: {
+                self
+            },
+            lockedContent: LogoView.init
+        )
     }
 }
 

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -30,11 +30,9 @@ import PassepartoutLibrary
 struct PassepartoutApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
-    @AppStorage(AppPreference.locksInBackground.rawValue) private var locksInBackground = false
-
     @SceneBuilder var body: some Scene {
         WindowGroup {
-            mainView
+            MainView()
                 .withoutTitleBar()
                 .onIntentActivity(IntentDispatcher.connectVPN)
                 .onIntentActivity(IntentDispatcher.disableVPN)
@@ -45,19 +43,6 @@ struct PassepartoutApp: App {
                 .onIntentActivity(IntentDispatcher.untrustCellularNetwork)
                 .onIntentActivity(IntentDispatcher.untrustCurrentNetwork)
         }
-    }
-
-    private var mainView: some View {
-        #if targetEnvironment(macCatalyst)
-        MainView()
-        #else
-        LockableView(
-            reason: L10n.Global.Messages.unlockApp,
-            locksInBackground: $locksInBackground,
-            content: MainView.init,
-            lockedContent: LogoView.init
-        )
-        #endif
     }
 }
 

--- a/Passepartout/App/Reusable/LockableView.swift
+++ b/Passepartout/App/Reusable/LockableView.swift
@@ -24,16 +24,15 @@
 //
 
 import SwiftUI
-import LocalAuthentication
 
 struct LockableView<Content: View, LockedContent: View>: View {
-    let reason: String
-
     @Binding var locksInBackground: Bool
 
     let content: () -> Content
 
     let lockedContent: () -> LockedContent
+
+    let unlockBlock: (Binding<Bool>) -> Void
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -84,20 +83,7 @@ struct LockableView<Content: View, LockedContent: View>: View {
         guard isLocked.wrappedValue else {
             return
         }
-        let context = LAContext()
-        let policy: LAPolicy = .deviceOwnerAuthentication
-        var error: NSError?
-        guard context.canEvaluatePolicy(policy, error: &error) else {
-            isLocked.wrappedValue = false
-            return
-        }
-        Task { @MainActor in
-            do {
-                let isAuthorized = try await context.evaluatePolicy(policy, localizedReason: reason)
-                isLocked.wrappedValue = !isAuthorized
-            } catch {
-            }
-        }
+        unlockBlock(isLocked)
     }
 }
 


### PR DESCRIPTION
- [x] After locking screen, navigation state is lost. Do not replace content, cover with a ZStack.
- [x] In order to do the above, apply lock screen to all NavigationView instances (modals) via .themeGlobal()
- [x] Share lock state across all screens

See #270