### PR TITLE
Drop #available condition on iOS 15

### DIFF
--- a/Passepartout/App/Constants/Theme.swift
+++ b/Passepartout/App/Constants/Theme.swift
@@ -45,10 +45,7 @@ extension View {
         #if targetEnvironment(macCatalyst)
         false
         #else
-        guard #available(iOS 15, *) else {
-            return false
-        }
-        return UIDevice.current.userInterfaceIdiom == .pad
+        UIDevice.current.userInterfaceIdiom == .pad
         #endif
     }
 }
@@ -106,11 +103,7 @@ extension View {
 
     @ViewBuilder
     private func themeTint() -> some View {
-        if #available(iOS 15, *) {
-            tint(.accentColor)
-        } else {
-            self
-        }
+        tint(.accentColor)
     }
 
     private func themeListStyleValue() -> some ListStyle {
@@ -118,11 +111,7 @@ extension View {
     }
 
     private func themeToggleStyleValue() -> some ToggleStyle {
-        if #available(iOS 15, *) {
-            return .switch
-        } else {
-            return SwitchToggleStyle(tint: .accentColor)
-        }
+        .switch
     }
 }
 

--- a/Passepartout/App/Reusable/DestructiveButton.swift
+++ b/Passepartout/App/Reusable/DestructiveButton.swift
@@ -31,10 +31,6 @@ struct DestructiveButton<Label: View>: View {
     let label: () -> Label
 
     var body: some View {
-        if #available(iOS 15, *) {
-            Button(role: .destructive, action: action, label: label)
-        } else {
-            Button(action: action, label: label)
-        }
+        Button(role: .destructive, action: action, label: label)
     }
 }

--- a/Passepartout/App/Views/OrganizerView+Profiles.swift
+++ b/Passepartout/App/Views/OrganizerView+Profiles.swift
@@ -148,6 +148,8 @@ extension OrganizerView {
         }
 
         var body: some View {
+
+            // XXX: iOS bug, before 16, context menu is not redrawn on VPN state change
             if #available(iOS 16, *), isActiveProfileNotDisconnected {
                 reconnectButton
             }

--- a/Passepartout/App/Views/ProviderLocationView.swift
+++ b/Passepartout/App/Views/ProviderLocationView.swift
@@ -99,14 +99,12 @@ struct ProviderLocationView: View, ProviderProfileAvailability {
                 EmptyView()
             }
         }.toolbar {
-            if #available(iOS 15, *) {
-                Button {
-                    withAnimation {
-                        isShowingFavorites.toggle()
-                    }
-                } label: {
-                    themeFavoritesImage(isShowingFavorites).asSystemImage
+            Button {
+                withAnimation {
+                    isShowingFavorites.toggle()
                 }
+            } label: {
+                themeFavoritesImage(isShowingFavorites).asSystemImage
             }
         }.navigationTitle(L10n.Provider.Location.title)
     }
@@ -133,7 +131,7 @@ struct ProviderLocationView: View, ProviderProfileAvailability {
     private func categorySection(_ category: ProviderCategory) -> some View {
         Section {
             ForEach(filteredLocations(for: category)) { location in
-                if isEditable, #available(iOS 15, *) {
+                if isEditable {
                     locationRow(location)
                         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                             favoriteActions(location)

--- a/Passepartout/App/Views/View+Extensions.swift
+++ b/Passepartout/App/Views/View+Extensions.swift
@@ -106,9 +106,7 @@ extension View {
 
 extension View {
     func debugChanges() {
-        if #available(iOS 15, *),
-           SwiftyBeaver.destinations.first?.minLevel == .verbose {
-
+        if SwiftyBeaver.destinations.first?.minLevel == .verbose {
             Self._printChanges()
         }
     }

--- a/PassepartoutLibrary/Sources/PassepartoutProfiles/Managers/ProfileManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutProfiles/Managers/ProfileManager.swift
@@ -230,9 +230,7 @@ extension ProfileManager {
         if setAsCurrent {
 
             // iOS 14 goes crazy when changing binding of a presented NavigationLink
-            if #available(iOS 15, *) {
-                internalCurrentProfileId = copy.id
-            }
+            internalCurrentProfileId = copy.id
 
             // autosaves copy if non-existing in persistent store
             setCurrentProfile(copy)


### PR DESCRIPTION
Target was bumped to iOS 15, so there's no point in keeping the condition.