### PR TITLE
Lock in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Option to lock app when entering background (iOS). [#270](https://github.com/passepartoutvpn/passepartout-apple/pull/270), [#271](https://github.com/passepartoutvpn/passepartout-apple/pull/271), [#273](https://github.com/passepartoutvpn/passepartout-apple/pull/273)
+- Option to lock app when entering background (iOS). [#270](https://github.com/passepartoutvpn/passepartout-apple/pull/270), [#271](https://github.com/passepartoutvpn/passepartout-apple/pull/271), [#273](https://github.com/passepartoutvpn/passepartout-apple/pull/273), [#275](https://github.com/passepartoutvpn/passepartout-apple/pull/275)
 - 3D Touch items (iOS). [#267](https://github.com/passepartoutvpn/passepartout-apple/pull/267)
 - Ukranian translations (Dmitry Chirkin). [#243](https://github.com/passepartoutvpn/passepartout-apple/pull/243)
 - Restore DNS "Domain" setting. [#260](https://github.com/passepartoutvpn/passepartout-apple/pull/260)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 3D Touch items (iOS). [#267](https://github.com/passepartoutvpn/passepartout-apple/pull/267)
 - Ukranian translations (Dmitry Chirkin). [#243](https://github.com/passepartoutvpn/passepartout-apple/pull/243)
 - Restore DNS "Domain" setting. [#260](https://github.com/passepartoutvpn/passepartout-apple/pull/260)
-- OpenVPN: Full implementation of Tunnelblick XOR patch (tmthecoder). [#245](https://github.com/passepartoutvpn/passepartout-apple/pull/245), [tunnelkit#255][https://github.com/passepartoutvpn/tunnelkit/pull/255]
+- OpenVPN: Full implementation of Tunnelblick XOR patch (tmthecoder). [#245](https://github.com/passepartoutvpn/passepartout-apple/pull/245), [tunnelkit#255](https://github.com/passepartoutvpn/tunnelkit/pull/255)
 - WireGuard: DoH/DoT options. [#264](https://github.com/passepartoutvpn/passepartout-apple/pull/264)
 
 ### Changed

--- a/Passepartout.xcodeproj/project.pbxproj
+++ b/Passepartout.xcodeproj/project.pbxproj
@@ -1167,7 +1167,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1400;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = "Davide De Rosa";
 				TargetAttributes = {
 					0E41BD96286711C3006346B4 = {
@@ -1905,6 +1905,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -1939,6 +1940,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/Passepartout.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/Passepartout.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutLauncher.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutLauncher.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutMac.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutMac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutTests.xcscheme
+++ b/Passepartout.xcodeproj/xcshareddata/xcschemes/PassepartoutTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Passepartout/App/Reusable/LockableView.swift
+++ b/Passepartout/App/Reusable/LockableView.swift
@@ -60,7 +60,7 @@ struct LockableView<Content: View, LockedContent: View>: View {
         case .active:
             unlockIfNeeded()
 
-        case .inactive:
+        case .background:
             lockIfNeeded()
 
         default:

--- a/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/OpenVPNAppExtension.xcscheme
+++ b/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/OpenVPNAppExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutLibrary.xcscheme
+++ b/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutLibrary.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutProvidersTests.xcscheme
+++ b/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutProvidersTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutServicesTests.xcscheme
+++ b/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutServicesTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutUtilsTests.xcscheme
+++ b/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/PassepartoutUtilsTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/WireGuardAppExtension.xcscheme
+++ b/PassepartoutLibrary/.swiftpm/xcode/xcshareddata/xcschemes/WireGuardAppExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Lock on `.background` rather than `.inactive`. There are plenty of situations where the app kind of stays in the foreground, but goes to `.inactive` state. Lock screen could be annoying in those cases.