### PR TITLE
Force Mac "Catalyst" idiom in debug log

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutLibrary/Extensions/DebugLog+Extensions.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutLibrary/Extensions/DebugLog+Extensions.swift
@@ -38,7 +38,11 @@ extension DebugLog {
         #if os(iOS)
         let device: UIDevice = .current
         osVersion = "\(device.systemName) \(device.systemVersion)"
+        #if targetEnvironment(macCatalyst)
+        deviceType = "\(device.model) (Catalyst)"
+        #else
         deviceType = "\(device.model) (\(device.userInterfaceIdiom.debugDescription))"
+        #endif
         #else
         let os = ProcessInfo().operatingSystemVersion
         osVersion = "macOS \(os.majorVersion).\(os.minorVersion).\(os.patchVersion)"


### PR DESCRIPTION
Mac Catalyst incorrectly reported as "Pad".