### PR TITLE
Use a distinct debug log per VPN protocol

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/OpenVPNSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/OpenVPNSettings+VPNConfiguration.swift
@@ -58,7 +58,9 @@ extension Profile.OpenVPNSettings: VPNConfigurationProviding {
         )
         cfg.username = parameters.username
         cfg.shouldDebug = true
-        cfg.debugLogPath = parameters.preferences.tunnelLogPath
+        if let filename = parameters.preferences.tunnelLogPath {
+            cfg.debugLogPath = vpnPath(with: filename)
+        }
         cfg.debugLogFormat = parameters.preferences.tunnelLogFormat
         cfg.masksPrivateData = parameters.preferences.masksPrivateData
 

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/VPNProtocolType+Extensions.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/VPNProtocolType+Extensions.swift
@@ -63,3 +63,11 @@ extension VPNProtocolType {
         true
     }
 }
+
+extension VPNProtocolProviding {
+    func vpnPath(with path: String) -> String {
+        var components = path.split(separator: "/").map(String.init)
+        components.insert(vpnProtocol.description, at: components.count - 1)
+        return components.joined(separator: "/")
+    }
+}

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
@@ -48,7 +48,9 @@ extension Profile.WireGuardSettings: VPNConfigurationProviding {
             configuration: customConfiguration
         )
         cfg.shouldDebug = true
-        cfg.debugLogPath = parameters.preferences.tunnelLogPath
+        if let filename = parameters.preferences.tunnelLogPath {
+            cfg.debugLogPath = vpnPath(with: filename)
+        }
         cfg.debugLogFormat = parameters.preferences.tunnelLogFormat
 
         var extra = NetworkExtensionExtra()


### PR DESCRIPTION
Log content from different tunnels was interleaved. Store debug logs in a protocol-specific folder.