### PR TITLE
Recognize IAPs other than full version on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve kill switch behavior. [#181](https://github.com/passepartoutvpn/passepartout-apple/issues/181)
 - Retain original filename as imported profile name. [#240](https://github.com/passepartoutvpn/passepartout-apple/pull/240)
+- In-app purchases other than full version were not recognized (macOS). [#281](https://github.com/passepartoutvpn/passepartout-apple/pull/281)
 
 ## 2.0.2 (2022-10-31)
 

--- a/Passepartout/App/InApp/ProductManager.swift
+++ b/Passepartout/App/InApp/ProductManager.swift
@@ -205,11 +205,7 @@ class ProductManager: NSObject, ObservableObject {
                 return true
             }
         }
-        if isMac {
-            return isFullVersion()
-        } else {
-            return isFullVersion() || purchasedFeatures.contains(feature)
-        }
+        return isFullVersion() || purchasedFeatures.contains(feature)
     }
 
     func isEligible(forProvider providerName: ProviderName) -> Bool {


### PR DESCRIPTION
Relic from version 1, where feature-specific IAPs used to only target iOS version.