### PR TITLE
Override manual DNS servers when using DoH/DoT

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
@@ -94,15 +94,7 @@ extension WireGuard.ConfigurationBuilder {
             break
 
         case .manual:
-            dnsServers = settings.dnsServers ?? []
-            var allDomains: [String] = []
-            if let domain = settings.dnsDomain {
-                allDomains.insert(domain, at: 0)
-            }
-            if let searchDomains = settings.dnsSearchDomains {
-                allDomains.append(contentsOf: searchDomains)
-            }
-            dnsSearchDomains = allDomains.filter { !$0.isEmpty }
+            let isDNSEnabled = settings.configurationType != .disabled
 
             switch settings.configurationType {
             case .plain:
@@ -115,6 +107,20 @@ extension WireGuard.ConfigurationBuilder {
                 dnsTLSServerName = settings.dnsTLSServerName
 
             case .disabled:
+                break
+            }
+
+            if isDNSEnabled {
+                dnsServers = settings.dnsServers ?? []
+                var allDomains: [String] = []
+                if let domain = settings.dnsDomain {
+                    allDomains.insert(domain, at: 0)
+                }
+                if let searchDomains = settings.dnsSearchDomains {
+                    allDomains.append(contentsOf: searchDomains)
+                }
+                dnsSearchDomains = allDomains.filter { !$0.isEmpty }
+            } else {
                 dnsServers = []
                 dnsSearchDomains = []
             }

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
@@ -94,9 +94,10 @@ extension WireGuard.ConfigurationBuilder {
             break
 
         case .manual:
+            dnsServers = settings.dnsServers ?? []
+
             switch settings.configurationType {
             case .plain:
-                dnsServers = settings.dnsServers ?? []
                 var allDomains: [String] = []
                 if let domain = settings.dnsDomain {
                     allDomains.insert(domain, at: 0)

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
@@ -95,17 +95,18 @@ extension WireGuard.ConfigurationBuilder {
 
         case .manual:
             dnsServers = settings.dnsServers ?? []
+            var allDomains: [String] = []
+            if let domain = settings.dnsDomain {
+                allDomains.insert(domain, at: 0)
+            }
+            if let searchDomains = settings.dnsSearchDomains {
+                allDomains.append(contentsOf: searchDomains)
+            }
+            dnsSearchDomains = allDomains.filter { !$0.isEmpty }
 
             switch settings.configurationType {
             case .plain:
-                var allDomains: [String] = []
-                if let domain = settings.dnsDomain {
-                    allDomains.insert(domain, at: 0)
-                }
-                if let searchDomains = settings.dnsSearchDomains {
-                    allDomains.append(contentsOf: searchDomains)
-                }
-                dnsSearchDomains = allDomains.filter { !$0.isEmpty }
+                break
 
             case .https:
                 dnsHTTPSURL = settings.dnsHTTPSURL


### PR DESCRIPTION
Manual DNS servers are ignored when using DoH/DoT, i.e. entries from .conf file are still taking over. That's why editing DNS servers in the .conf file is a successful workaround.

Erroneously left out from #264.