### PR TITLE
Roll back broken TunnelKit .killSwitch flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Roll back broken kill switch flag. [#294](https://github.com/passepartoutvpn/passepartout-apple/pull/294)
 - Remove nonsense Mac menus (macOS). [#285](https://github.com/passepartoutvpn/passepartout-apple/pull/285)
 
 ## 2.1.0 (2023-04-07)

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/OpenVPNSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/OpenVPNSettings+VPNConfiguration.swift
@@ -68,7 +68,6 @@ extension Profile.OpenVPNSettings: VPNConfigurationProviding {
         extra.passwordReference = parameters.passwordReference
         extra.onDemandRules = parameters.onDemandRules
         extra.disconnectsOnSleep = !parameters.networkSettings.keepsAliveOnSleep
-        extra.killSwitch = true
 
         pp_log.verbose("Configuration:")
         pp_log.verbose(cfg)

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Extensions/WireGuardSettings+VPNConfiguration.swift
@@ -56,7 +56,6 @@ extension Profile.WireGuardSettings: VPNConfigurationProviding {
         var extra = NetworkExtensionExtra()
         extra.onDemandRules = parameters.onDemandRules
         extra.disconnectsOnSleep = !parameters.networkSettings.keepsAliveOnSleep
-        extra.killSwitch = true
 
         pp_log.verbose("Configuration:")
         pp_log.verbose(cfg)


### PR DESCRIPTION
Use of [.includeAllNetworks](https://developer.apple.com/documentation/networkextension/nevpnprotocol/3131931-includeallnetworks) in TunnelKit may have caused severe connectivity regressions in 2.1.0