### PR TITLE
Revisit domain name validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Allow wildcards in proxy bypass domains. [#296](https://github.com/passepartoutvpn/passepartout-apple/issues/296)
+
 ## 2.1.1 (2023-04-19)
 
 ### Added

--- a/Passepartout/App/Constants/Theme.swift
+++ b/Passepartout/App/Constants/Theme.swift
@@ -546,6 +546,12 @@ extension View {
             .themeRawTextStyle()
     }
 
+    func themeValidWildcardDomainName(_ domainName: String?) -> some View {
+        themeValidating(domainName, validator: Validators.wildcardDomainName)
+            .keyboardType(.asciiCapable)
+            .themeRawTextStyle()
+    }
+
     func themeValidDNSOverTLSServerName(_ string: String?) -> some View {
         themeValidating(string, validator: Validators.dnsOverTLSServerName)
             .keyboardType(.asciiCapable)

--- a/Passepartout/App/Reusable/Validators.swift
+++ b/Passepartout/App/Reusable/Validators.swift
@@ -35,8 +35,14 @@ struct Validators {
 
         case domainName
 
+        case wildcardDomainName
+
         case url
     }
+
+    private static let rxDomainName = NSRegularExpression("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,}$")
+
+    private static let rxWildcardDomainName = NSRegularExpression("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.|\\*\\.)+([A-Za-z]{2,}|\\*)$")
 
     static func notNil(_ string: String?) throws {
         guard string != nil else {
@@ -64,11 +70,15 @@ struct Validators {
         throw ValidationError.ipAddress
     }
 
-    private static let rxDomainName = NSRegularExpression("^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$")
-
     static func domainName(_ string: String) throws {
         guard rxDomainName.numberOfMatches(in: string, options: [], range: .init(location: 0, length: string.count)) > 0 else {
             throw ValidationError.domainName
+        }
+    }
+
+    static func wildcardDomainName(_ string: String) throws {
+        guard rxWildcardDomainName.numberOfMatches(in: string, options: [], range: .init(location: 0, length: string.count)) > 0 else {
+            throw ValidationError.wildcardDomainName
         }
     }
 

--- a/Passepartout/App/Views/NetworkSettingsView.swift
+++ b/Passepartout/App/Views/NetworkSettingsView.swift
@@ -261,7 +261,7 @@ extension NetworkSettingsView {
                     text: $0.text,
                     onEditingChanged: $0.onEditingChanged,
                     onCommit: $0.onCommit
-                ).themeValidDomainName($0.text.wrappedValue)
+                ).themeValidWildcardDomainName($0.text.wrappedValue)
             } addLabel: {
                 Text(L10n.NetworkSettings.Items.AddProxyBypass.caption)
                 } commitLabel: {


### PR DESCRIPTION
Allow:

- TLDs longer than 6 characters
- Wildcards in [proxy bypass domains](https://github.com/passepartoutvpn/passepartout-apple/issues/296)

Fixes #296 