### PR TITLE
Shift dependency on GenericJSON

### DIFF
--- a/PassepartoutLibrary/Package.swift
+++ b/PassepartoutLibrary/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
             dependencies: [
                 "PassepartoutVPN",
                 "SwiftyBeaver",
+                .product(name: "GenericJSON", package: "generic-json-swift"),
                 .product(name: "TunnelKitLZO", package: "TunnelKit")
             ],
             resources: [
@@ -84,9 +85,7 @@ let package = Package(
             ]),
         .target(
             name: "PassepartoutCore",
-            dependencies: [
-                .product(name: "GenericJSON", package: "generic-json-swift") // FIXME: arch, drop this
-            ]),
+            dependencies: []),
 
         // MARK: App extensions
 

--- a/PassepartoutLibrary/Sources/PassepartoutCore/Domain/GenericMap.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutCore/Domain/GenericMap.swift
@@ -1,8 +1,8 @@
 //
-//  WSProviderPreset.swift
+//  GenericMap.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 8/30/18.
+//  Created by Davide De Rosa on 5/27/23.
 //  Copyright (c) 2023 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -24,38 +24,7 @@
 //
 
 import Foundation
-import PassepartoutCore
 
-public struct WSProviderPreset: Codable {
-    enum CodingKeys: String, CodingKey {
-        case id
-
-        case name
-
-        case comment
-
-        case external
-
-        case jsonOpenVPNConfiguration = "ovpn"
-
-        case jsonWireGuardConfiguration = "wg"
-    }
-
-    public let id: String
-
-    public let name: String
-
-    public let comment: String
-
-    public var external: [String: String]?
-
-    public var jsonOpenVPNConfiguration: GenericMap?
-
-    public var jsonWireGuardConfiguration: GenericMap?
-
-    public init(id: String, name: String, comment: String) {
-        self.id = id
-        self.name = name
-        self.comment = comment
-    }
+public struct GenericMap {
+    public let map: [String: Any]
 }

--- a/PassepartoutLibrary/Sources/PassepartoutCore/Reusable/GenericMap+Codable.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutCore/Reusable/GenericMap+Codable.swift
@@ -1,8 +1,8 @@
 //
-//  JSON+Codable.swift
+//  GenericMap+Codable.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 3/13/22.
+//  Created by Davide De Rosa on 5/27/23.
 //  Copyright (c) 2023 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -24,9 +24,27 @@
 //
 
 import Foundation
-import GenericJSON
 
-extension JSON {
+extension GenericMap: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let data = try container.decode(Data.self)
+        let map = try jsonDecode(data)
+        self.init(map: map)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let data = try jsonEncode(map)
+        try container.encode(data)
+    }
+}
+
+extension GenericMap {
+    public static func decode(_ data: Data) throws -> GenericMap {
+        .init(map: try jsonDecode(data))
+    }
+
     public func decode<T: Decodable>(_ type: T.Type) throws -> T {
         let data = try JSONEncoder().encode(self)
         return try JSONDecoder().decode(type, from: data)
@@ -35,4 +53,12 @@ extension JSON {
     public func encoded() throws -> Data {
         try JSONEncoder().encode(self)
     }
+}
+
+private func jsonEncode(_ map: [String: Any]) throws -> Data {
+    try JSONSerialization.data(withJSONObject: map)
+}
+
+private func jsonDecode(_ data: Data) throws -> [String: Any] {
+    try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
 }

--- a/PassepartoutLibrary/Sources/PassepartoutProviders/Domain/ProviderServer.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutProviders/Domain/ProviderServer.swift
@@ -24,7 +24,6 @@
 //
 
 import Foundation
-import GenericJSON
 import PassepartoutCore
 
 public struct ProviderServer {
@@ -37,9 +36,9 @@ public struct ProviderServer {
 
         public let vpnProtocol: VPNProtocolType
 
-        public let vpnConfiguration: JSON
+        public let vpnConfiguration: GenericMap
 
-        public init(id: String, name: String, comment: String, vpnProtocol: VPNProtocolType, vpnConfiguration: JSON) {
+        public init(id: String, name: String, comment: String, vpnProtocol: VPNProtocolType, vpnConfiguration: GenericMap) {
             self.id = id
             self.name = name
             self.comment = comment

--- a/PassepartoutLibrary/Sources/PassepartoutProvidersImpl/Strategies/PresetMapper.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutProvidersImpl/Strategies/PresetMapper.swift
@@ -25,7 +25,6 @@
 
 import CoreData
 import Foundation
-import GenericJSON
 import PassepartoutCore
 import PassepartoutProviders
 import PassepartoutServices
@@ -76,22 +75,21 @@ struct PresetMapper: DTOMapper, ModelMapper {
 
 private extension WSProviderPreset {
     var encodedOpenVPNConfiguration: Data? {
-        return try? jsonOpenVPNConfiguration?.encoded()
+        try? jsonOpenVPNConfiguration?.encoded()
     }
 
     var encodedWireGuardConfiguration: Data? {
-        return try? jsonWireGuardConfiguration?.encoded()
+        try? jsonWireGuardConfiguration?.encoded()
     }
 }
 
 private extension CDInfrastructurePreset {
-    var decodedConfiguration: JSON? {
+    var decodedConfiguration: GenericMap? {
         guard let configuration = vpnConfiguration else {
             return nil
         }
         do {
-            let raw = try JSONSerialization.jsonObject(with: configuration)
-            return try JSON(raw)
+            return try GenericMap.decode(configuration)
         } catch {
             pp_log.error("Unable to decode vpnConfiguration: \(error)")
             return nil

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/JSON+Codable.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/JSON+Codable.swift
@@ -1,8 +1,8 @@
 //
-//  WSProviderPreset.swift
+//  JSON+Codable.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 8/30/18.
+//  Created by Davide De Rosa on 3/13/22.
 //  Copyright (c) 2023 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -24,38 +24,20 @@
 //
 
 import Foundation
+import GenericJSON
 import PassepartoutCore
 
-public struct WSProviderPreset: Codable {
-    enum CodingKeys: String, CodingKey {
-        case id
-
-        case name
-
-        case comment
-
-        case external
-
-        case jsonOpenVPNConfiguration = "ovpn"
-
-        case jsonWireGuardConfiguration = "wg"
+extension JSON {
+    public init(_ genericMap: GenericMap) throws {
+        try self.init(genericMap.map)
     }
 
-    public let id: String
+    public func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        let data = try JSONEncoder().encode(self)
+        return try JSONDecoder().decode(type, from: data)
+    }
 
-    public let name: String
-
-    public let comment: String
-
-    public var external: [String: String]?
-
-    public var jsonOpenVPNConfiguration: GenericMap?
-
-    public var jsonWireGuardConfiguration: GenericMap?
-
-    public init(id: String, name: String, comment: String) {
-        self.id = id
-        self.name = name
-        self.comment = comment
+    public func encoded() throws -> Data {
+        try JSONEncoder().encode(self)
     }
 }

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/JSON+Codable.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/JSON+Codable.swift
@@ -28,6 +28,8 @@ import GenericJSON
 import PassepartoutCore
 
 extension JSON {
+
+    // IMPORTANT: must specialize default init(Any) as it only handles Foundation values
     public init(_ genericMap: GenericMap) throws {
         try self.init(genericMap.map)
     }

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/PassepartoutProviders+TunnelKit.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/PassepartoutProviders+TunnelKit.swift
@@ -25,6 +25,7 @@
 
 import Combine
 import Foundation
+import GenericJSON
 import PassepartoutCore
 import PassepartoutProviders
 import TunnelKitOpenVPN
@@ -35,7 +36,10 @@ extension ProviderServer.Preset {
         guard vpnProtocol == .openVPN else {
             return nil
         }
-        guard let json = vpnConfiguration["cfg"] else {
+        guard let wrapper = try? JSON(vpnConfiguration) else {
+            return nil
+        }
+        guard let json = wrapper["cfg"] else {
             pp_log.error("Unable to parse preset OpenVPN configuration: no cfg")
             return nil
         }
@@ -51,7 +55,10 @@ extension ProviderServer.Preset {
         guard vpnProtocol == .openVPN else {
             return []
         }
-        guard let json = vpnConfiguration["endpoints"]?.arrayValue else {
+        guard let wrapper = try? JSON(vpnConfiguration) else {
+            return []
+        }
+        guard let json = wrapper["endpoints"]?.arrayValue else {
             pp_log.error("Unable to parse preset OpenVPN configuration: no endpoints")
             return []
         }

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/PassepartoutProviders+TunnelKit.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/PassepartoutProviders+TunnelKit.swift
@@ -36,7 +36,11 @@ extension ProviderServer.Preset {
         guard vpnProtocol == .openVPN else {
             return nil
         }
-        guard let wrapper = try? JSON(vpnConfiguration) else {
+        let wrapper: JSON
+        do {
+            wrapper = try JSON(vpnConfiguration)
+        } catch {
+            pp_log.error("Unable to parse generic vpnConfiguration: \(error)")
             return nil
         }
         guard let json = wrapper["cfg"] else {
@@ -55,7 +59,11 @@ extension ProviderServer.Preset {
         guard vpnProtocol == .openVPN else {
             return []
         }
-        guard let wrapper = try? JSON(vpnConfiguration) else {
+        let wrapper: JSON
+        do {
+            wrapper = try JSON(vpnConfiguration)
+        } catch {
+            pp_log.error("Unable to parse generic vpnConfiguration: \(error)")
             return []
         }
         guard let json = wrapper["endpoints"]?.arrayValue else {


### PR DESCRIPTION
Most packages don't need to decode map internals, i.e. provider presets and VPN configurations, only the VPNImpl package does. Therefore, plug the dependency there and rely on generic `[String: Any]` in all the underlying packages.

- [ ] Host profile (de)deserialization
- [ ] Provider profile (de)serialization