### PR TITLE
Fail gracefully when refreshing infrastructure

### DIFF
--- a/Passepartout/App/Views/ProfileView+Provider.swift
+++ b/Passepartout/App/Views/ProfileView+Provider.swift
@@ -148,7 +148,7 @@ extension ProfileView {
         private func refreshInfrastructure() {
             isRefreshingInfrastructure = true
             Task { @MainActor in
-                try await providerManager.fetchRemoteProviderPublisher(forProfile: profile).async()
+                try? await providerManager.fetchRemoteProviderPublisher(forProfile: profile).async()
                 isRefreshingInfrastructure = false
             }
         }


### PR DESCRIPTION
On failure, the progress widget keeps spinning, because the unhandled error ends the `Task` abruptly.