### PR TITLE
Move VPNProtocolType serialization to Data layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Changed
-
-- Internal error handling. [#310](https://github.com/passepartoutvpn/passepartout-apple/pull/310)
-
 ### Fixed
 
 - Allow wildcards in proxy bypass domains. [#296](https://github.com/passepartoutvpn/passepartout-apple/issues/296)
+- Fail gracefully when refreshing infrastructure. [#307](https://github.com/passepartoutvpn/passepartout-apple/pull/307)
+- Only show 'Reconnect' on active profile. [#311](https://github.com/passepartoutvpn/passepartout-apple/pull/311)
+- IPv4/6 address validation. [#308](https://github.com/passepartoutvpn/passepartout-apple/pull/308)
+- Domain name validation. [#297](https://github.com/passepartoutvpn/passepartout-apple/pull/297)
 
 ## 2.1.1 (2023-04-19)
 

--- a/PassepartoutLibrary/Sources/PassepartoutProviders/Extensions/Domain+Identifiable.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutProviders/Extensions/Domain+Identifiable.swift
@@ -57,7 +57,7 @@ extension ProviderServer: Identifiable {
     }
 
     public static func id(withName providerName: ProviderName, vpnProtocol: VPNProtocolType, apiId: String) -> String? {
-        let idSource = [providerName, vpnProtocol.rawValue, apiId].joined(separator: ":")
+        let idSource = [providerName, "\(vpnProtocol)", apiId].joined(separator: ":")
         guard let data = idSource.data(using: .utf8) else {
             return nil
         }

--- a/PassepartoutLibrary/Sources/PassepartoutProvidersImpl/Strategies/VPNProtocolType+RawRepresentable.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutProvidersImpl/Strategies/VPNProtocolType+RawRepresentable.swift
@@ -1,8 +1,8 @@
 //
-//  VPNProtocolType.swift
+//  VPNProtocolType+RawRepresentable.swift
 //  Passepartout
 //
-//  Created by Davide De Rosa on 3/20/22.
+//  Created by Davide De Rosa on 7/2/23.
 //  Copyright (c) 2023 Davide De Rosa. All rights reserved.
 //
 //  https://github.com/passepartoutvpn
@@ -24,13 +24,33 @@
 //
 
 import Foundation
+import PassepartoutCore
 
-public enum VPNProtocolType: CaseIterable, Codable {
-    case openVPN
+extension VPNProtocolType: RawRepresentable {
+    private static let openVPNString = "ovpn"
 
-    case wireGuard
-}
+    private static let wireGuardString = "wg"
 
-public protocol VPNProtocolProviding {
-    var vpnProtocol: VPNProtocolType { get }
+    public init?(rawValue: String) {
+        switch rawValue {
+        case Self.openVPNString:
+            self = .openVPN
+
+        case Self.wireGuardString:
+            self = .wireGuard
+
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .openVPN:
+            return Self.openVPNString
+
+        case .wireGuard:
+            return Self.wireGuardString
+        }
+    }
 }


### PR DESCRIPTION
It's crucial that the data layer has full control over how entities are (de)serialized.

Do not leave this choice up to the domain layer by defining an enum as a raw value type, because any change in the enum raw value would literally be a disaster, i.e. _any_ serialized data would break instantly.