### PR TITLE
Extend error handler to modals

### DIFF
--- a/Passepartout/App/Constants/Theme.swift
+++ b/Passepartout/App/Constants/Theme.swift
@@ -62,6 +62,7 @@ extension View {
             .listStyle(themeListStyleValue())
             .toggleStyle(themeToggleStyleValue())
             .menuStyle(.borderlessButton)
+            .withErrorHandler()
     }
 
     func themePrimaryView() -> some View {

--- a/Passepartout/App/PassepartoutApp.swift
+++ b/Passepartout/App/PassepartoutApp.swift
@@ -34,7 +34,6 @@ struct PassepartoutApp: App {
         WindowGroup {
             MainView()
                 .withoutTitleBar()
-                .withErrorHandler()
                 .onIntentActivity(IntentDispatcher.connectVPN)
                 .onIntentActivity(IntentDispatcher.disableVPN)
                 .onIntentActivity(IntentDispatcher.enableVPN)


### PR DESCRIPTION
Alert was not appearing in modals, because it must be explicitly attached to NavigationView.