### PR TITLE
Throw error on reinstate()/connect()

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Managers/VPNManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Managers/VPNManager.swift
@@ -87,7 +87,7 @@ public final class VPNManager: ObservableObject {
         clearLastError()
         do {
             let parameters = try vpnConfigurationParameters(withProfile: profile)
-            await strategy.reinstate(parameters)
+            try await strategy.reinstate(parameters)
         } catch {
             pp_log.error("Unable to build configuration: \(error)")
             throw error
@@ -99,7 +99,7 @@ public final class VPNManager: ObservableObject {
         clearLastError()
         do {
             let parameters = try vpnConfigurationParameters(withProfile: profile)
-            await strategy.connect(parameters)
+            try await strategy.connect(parameters)
         } catch {
             pp_log.error("Unable to build configuration: \(error)")
             throw error

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Strategies/VPNManagerStrategy.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Strategies/VPNManagerStrategy.swift
@@ -31,9 +31,9 @@ import PassepartoutProviders
 public protocol VPNManagerStrategy {
     func observe(into state: MutableObservableVPNState)
 
-    func reinstate(_ parameters: VPNConfigurationParameters) async
+    func reinstate(_ parameters: VPNConfigurationParameters) async throws
 
-    func connect(_ parameters: VPNConfigurationParameters) async
+    func connect(_ parameters: VPNConfigurationParameters) async throws
 
     func reconnect() async
 

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/TunnelKitVPNManagerStrategy.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/TunnelKitVPNManagerStrategy.swift
@@ -132,10 +132,8 @@ extension TunnelKitVPNManagerStrategy {
             }.store(in: &cancellables)
     }
 
-    public func reinstate(_ parameters: VPNConfigurationParameters) async {
-        guard let configuration = try? vpnConfiguration(withParameters: parameters) else {
-            return
-        }
+    public func reinstate(_ parameters: VPNConfigurationParameters) async throws {
+        let configuration = try vpnConfiguration(withParameters: parameters)
         guard let vpnType = configuration.neConfiguration as? VPNProtocolProviding else {
             fatalError("Configuration must implement VPNProtocolProviding")
         }
@@ -155,10 +153,8 @@ extension TunnelKitVPNManagerStrategy {
         }
     }
 
-    public func connect(_ parameters: VPNConfigurationParameters) async {
-        guard let configuration = try? vpnConfiguration(withParameters: parameters) else {
-            return
-        }
+    public func connect(_ parameters: VPNConfigurationParameters) async throws {
+        let configuration = try vpnConfiguration(withParameters: parameters)
         guard let vpnType = configuration.neConfiguration as? VPNProtocolProviding else {
             fatalError("Configuration must implement VPNProtocolProviding")
         }


### PR DESCRIPTION
Errors here were just being ignored, thus preventing error alert from appearing.