### PR TITLE
Restore on-demand backward compatibility

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Domain/Profile+OnDemand.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Domain/Profile+OnDemand.swift
@@ -49,6 +49,8 @@ extension Profile {
 
         public var withOtherNetworks: Set<OtherNetwork> = []
 
+        public var disconnectsIfNotMatching: Bool? = true
+
         public init() {
         }
     }

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Domain/Profile+OnDemand.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Domain/Profile+OnDemand.swift
@@ -49,6 +49,7 @@ extension Profile {
 
         public var withOtherNetworks: Set<OtherNetwork> = []
 
+        @available(*, deprecated, message: "Drop field after releasing as optional to the App Store")
         public var disconnectsIfNotMatching: Bool? = true
 
         public init() {

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/CDProfileRepository.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/CDProfileRepository.swift
@@ -98,7 +98,12 @@ final class CDProfileRepository: ProfileRepository {
             existing.forEach(context.delete)
 
             try profiles.forEach {
-                _ = try ProfileMapper(context).toDTO($0)
+
+                // FIXME: on-demand, workaround to retain profiles on downgrade (field is required before 2.2.0)
+                var copy = $0
+                copy.onDemand.disconnectsIfNotMatching = true
+
+                _ = try ProfileMapper(context).toDTO(copy)
             }
             try context.save()
         } catch {


### PR DESCRIPTION
In #333, the non-optional field `disconnectsIfNotMatching` was removed completely. Therefore, downgrading from 2.2.0 may lose profiles due to the missing required field.

Mitigate the issue by restoring the field as optional, even if it's unused, for the sake of not breaking profile serialization until the 2.2.0 release. Remove the deprecated field after that.