### PR TITLE
Omit footer when on-demand is disabled

### DIFF
--- a/Passepartout/App/Views/OnDemandView.swift
+++ b/Passepartout/App/Views/OnDemandView.swift
@@ -77,12 +77,15 @@ private extension OnDemandView {
                 )
             }
         } footer: {
-            Text(policyFooterDescription)
+            Text(policyFooterDescription ?? "")
         }
     }
 
     // FIXME: l10n, on-demand
     var policyFooterDescription: String {
+        guard onDemand.isEnabled else {
+            return "" // better animation than removing footer completely
+        }
         let suffix: String
         switch onDemand.policy {
         case .any:


### PR DESCRIPTION
Preserve footer in that case, just empty. Adding/removing footer seems to result in a worse animation.