### PR TITLE
Always read profiles from fetched value

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Managers/ProfileManager+Extensions.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Managers/ProfileManager+Extensions.swift
@@ -28,7 +28,7 @@ import PassepartoutCore
 
 extension ProfileManager {
     public var hasProfiles: Bool {
-        !profiles.isEmpty
+        !allProfiles.isEmpty
     }
 
     public var activeProfile: Profile? {

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Managers/ProfileManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Managers/ProfileManager.swift
@@ -113,12 +113,12 @@ public final class ProfileManager: ObservableObject {
 // MARK: Index
 
 extension ProfileManager {
-    private var allProfiles: [UUID: Profile] {
+    public var allProfiles: [UUID: Profile] {
         profileRepository.allProfiles()
     }
 
     public var profiles: [Profile] {
-        profileRepository.profiles()
+        Array(allProfiles.values)
     }
 
     public var headers: [Profile.Header] {

--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Strategies/ProfileRepository.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Strategies/ProfileRepository.swift
@@ -30,8 +30,6 @@ import PassepartoutCore
 public protocol ProfileRepository {
     func allProfiles() -> [UUID: Profile]
 
-    func profiles() -> [Profile]
-
     func profile(withId id: UUID) -> Profile?
 
     func saveProfiles(_ profiles: [Profile]) throws

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/CDProfileRepository.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/CDProfileRepository.swift
@@ -44,45 +44,8 @@ final class CDProfileRepository: ProfileRepository {
         observableProfiles.value
     }
 
-    func profiles() -> [Profile] {
-        let request = CDProfile.fetchRequest()
-        request.sortDescriptors = [
-            .init(keyPath: \CDProfile.lastUpdate, ascending: true)
-        ]
-        do {
-            let results = try context.fetch(request)
-            let map = try results.reduce(into: [UUID: Profile]()) {
-                guard let profile = try ProfileMapper.toModel($1) else {
-                    return
-                }
-                $0[profile.id] = profile
-            }
-            return Array(map.values)
-        } catch {
-            pp_log.error("Unable to fetch profiles: \(error)")
-            return []
-        }
-    }
-
     func profile(withId id: UUID) -> Profile? {
-        let request = CDProfile.fetchRequest()
-        request.predicate = NSPredicate(
-            format: "uuid == %@",
-            id.uuidString
-        )
-        request.sortDescriptors = [
-            .init(keyPath: \CDProfile.lastUpdate, ascending: false)
-        ]
-        do {
-            let results = try context.fetch(request)
-            guard let recent = results.first else {
-                return nil
-            }
-            return try ProfileMapper.toModel(recent)
-        } catch {
-            pp_log.error("Unable to fetch profile: \(error)")
-            return nil
-        }
+        observableProfiles.value[id]
     }
 
     func saveProfiles(_ profiles: [Profile]) throws {


### PR DESCRIPTION
There may be a mismatch between profiles and profile headers. For example, some profiles may appear in the main list, but the same ones may not appear in the existing profile names when adding a new profile (and vice versa). That's because they are being fetched from different sources. Unify that.