### PR TITLE
Suppress SceneConfiguration warning

### DIFF
--- a/Passepartout/App/Info.plist
+++ b/Passepartout/App/Info.plist
@@ -67,6 +67,8 @@
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
 		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
 	</dict>
 	<key>UIBackgroundModes</key>
 	<array>


### PR DESCRIPTION
```
Info.plist contained no UIScene configuration dictionary (looking for configuration named "SceneDelegate")
```

Just another missing entry from Info.plist