### PR TITLE
Retain persistence objects in manager

### DIFF
--- a/Passepartout/App/Context/AppContext.swift
+++ b/Passepartout/App/Context/AppContext.swift
@@ -61,7 +61,11 @@ final class AppContext {
             buildProducts: Constants.InApp.buildProducts
         )
 
-        persistenceManager = PersistenceManager(store: store)
+        persistenceManager = PersistenceManager(
+            store: store,
+            ckContainerId: Constants.CloudKit.containerId,
+            ckCoreDataZone: Constants.CloudKit.coreDataZone
+        )
 
         reviewer = Reviewer()
         reviewer.eventCountBeforeRating = Constants.Rating.eventCount

--- a/Passepartout/App/Context/CoreContext.swift
+++ b/Passepartout/App/Context/CoreContext.swift
@@ -23,7 +23,6 @@
 //  along with Passepartout.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-import CloudKit
 import Combine
 import Foundation
 import PassepartoutLibrary
@@ -118,15 +117,11 @@ private extension CoreContext {
 
         persistenceManager.didChangePersistence
             .sink { [weak self] in
-                self?.reloadCloudKitObjects(persistenceManager: persistenceManager)
+                self?.reloadPersistenceObjects(persistenceManager: persistenceManager)
             }.store(in: &cancellables)
     }
-}
 
-// MARK: CloudKit
-
-extension CoreContext {
-    func reloadCloudKitObjects(persistenceManager: PersistenceManager) {
+    func reloadPersistenceObjects(persistenceManager: PersistenceManager) {
         let vpnPersistence = persistenceManager.loadVPNPersistence(
             withName: Constants.Persistence.profilesContainerName
         )

--- a/Passepartout/App/Context/CoreContext.swift
+++ b/Passepartout/App/Context/CoreContext.swift
@@ -45,10 +45,10 @@ final class CoreContext {
     init(persistenceManager: PersistenceManager) {
         store = persistenceManager.store
 
-        let vpnPersistence = persistenceManager.vpnPersistence(
+        let vpnPersistence = persistenceManager.loadVPNPersistence(
             withName: Constants.Persistence.profilesContainerName
         )
-        let providersPersistence = persistenceManager.providersPersistence(
+        let providersPersistence = persistenceManager.loadProvidersPersistence(
             withName: Constants.Persistence.providersContainerName
         )
 
@@ -127,7 +127,7 @@ private extension CoreContext {
 
 extension CoreContext {
     func reloadCloudKitObjects(persistenceManager: PersistenceManager) {
-        let vpnPersistence = persistenceManager.vpnPersistence(
+        let vpnPersistence = persistenceManager.loadVPNPersistence(
             withName: Constants.Persistence.profilesContainerName
         )
         profileManager.swapProfileRepository(vpnPersistence.profileRepository())

--- a/Passepartout/App/Managers/PersistenceManager.swift
+++ b/Passepartout/App/Managers/PersistenceManager.swift
@@ -32,6 +32,10 @@ import PassepartoutLibrary
 final class PersistenceManager: ObservableObject {
     let store: KeyValueStore
 
+    private let ckContainerId: String
+
+    private let ckCoreDataZone: String
+
     private var vpnPersistence: VPNPersistence?
 
     private var providersPersistence: ProvidersPersistence?
@@ -47,8 +51,10 @@ final class PersistenceManager: ObservableObject {
 
     let didChangePersistence = PassthroughSubject<Void, Never>()
 
-    init(store: KeyValueStore) {
+    init(store: KeyValueStore, ckContainerId: String, ckCoreDataZone: String) {
         self.store = store
+        self.ckContainerId = ckContainerId
+        self.ckCoreDataZone = ckCoreDataZone
         isCloudSyncingEnabled = store.canEnableCloudSyncing
 
         // set once
@@ -78,8 +84,8 @@ extension PersistenceManager {
             isErasingCloudKitStore = true
         }
         await Self.eraseCloudKitStore(
-            fromContainerWithId: Constants.CloudKit.containerId,
-            zoneId: .init(zoneName: Constants.CloudKit.coreDataZone)
+            fromContainerWithId: ckContainerId,
+            zoneId: .init(zoneName: ckCoreDataZone)
         )
         await MainActor.run {
             isErasingCloudKitStore = false

--- a/Passepartout/App/Managers/PersistenceManager.swift
+++ b/Passepartout/App/Managers/PersistenceManager.swift
@@ -32,6 +32,10 @@ import PassepartoutLibrary
 final class PersistenceManager: ObservableObject {
     let store: KeyValueStore
 
+    private var vpnPersistence: VPNPersistence?
+
+    private var providersPersistence: ProvidersPersistence?
+
     private(set) var isCloudSyncingEnabled: Bool {
         didSet {
             pp_log.info("CloudKit enabled: \(isCloudSyncingEnabled)")
@@ -53,12 +57,16 @@ final class PersistenceManager: ObservableObject {
         }
     }
 
-    func vpnPersistence(withName containerName: String) -> VPNPersistence {
-        VPNPersistence(withName: containerName, cloudKit: isCloudSyncingEnabled, author: persistenceAuthor)
+    func loadVPNPersistence(withName containerName: String) -> VPNPersistence {
+        let persistence = VPNPersistence(withName: containerName, cloudKit: isCloudSyncingEnabled, author: persistenceAuthor)
+        vpnPersistence = persistence
+        return persistence
     }
 
-    func providersPersistence(withName containerName: String) -> ProvidersPersistence {
-        ProvidersPersistence(withName: containerName, cloudKit: false, author: persistenceAuthor)
+    func loadProvidersPersistence(withName containerName: String) -> ProvidersPersistence {
+        let persistence = ProvidersPersistence(withName: containerName, cloudKit: false, author: persistenceAuthor)
+        providersPersistence = persistence
+        return persistence
     }
 }
 


### PR DESCRIPTION
Relying on Core Data for context retention is fragile, better to keep a reference of the *Persistence objects ourselves.

Also, remove any CloudKit reference from CoreContext.