### PR TITLE
Disable nonsense tests

### DIFF
--- a/Passepartout.xctestplan
+++ b/Passepartout.xctestplan
@@ -45,6 +45,7 @@
   },
   "testTargets" : [
     {
+      "enabled" : false,
       "target" : {
         "containerPath" : "container:PassepartoutLibrary",
         "identifier" : "PassepartoutCoreTests",
@@ -52,6 +53,7 @@
       }
     },
     {
+      "enabled" : false,
       "target" : {
         "containerPath" : "container:PassepartoutLibrary",
         "identifier" : "PassepartoutProvidersTests",


### PR DESCRIPTION
ATM they are not tests and are completely meaningless. Also expensive as they hit the live GitHub API. Disable until fixed.