### PR TITLE
Encrypt profiles stored to iCloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Upgrade OpenSSL to 3.2.0. [tunnelkit#336](https://github.com/passepartoutvpn/tunnelkit/issues/336)
+### Added
+
 - WireGuard: Show data count. [#312](https://github.com/passepartoutvpn/passepartout-apple/issues/312)
+
+### Changed
+
+- Upgrade OpenSSL to 3.2.0. [tunnelkit#336](https://github.com/passepartoutvpn/tunnelkit/issues/336)
+- Encrypt profiles stored to iCloud. [#436](https://github.com/passepartoutvpn/passepartout-apple/pull/436)
 
 ## 2.2.1 (2023-10-14)
 

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Data/CDProfile+CoreDataProperties.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Data/CDProfile+CoreDataProperties.swift
@@ -17,6 +17,7 @@ extension CDProfile {
     }
 
     @NSManaged var json: Data?
+    @NSManaged var encryptedJSON: Data?
     @NSManaged var name: String?
     @NSManaged var providerName: String?
     @NSManaged var uuid: UUID?

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Data/Profiles.xcdatamodeld/Model.xcdatamodel/contents
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Data/Profiles.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E230" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="1.0">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E252" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="1.0">
     <entity name="CDProfile" representedClassName="CDProfile" syncable="YES">
+        <attribute name="encryptedJSON" optional="YES" attributeType="Binary" allowsCloudEncryption="YES"/>
         <attribute name="json" optional="YES" attributeType="Binary"/>
         <attribute name="lastUpdate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="providerName" optional="YES" attributeType="String"/>
         <attribute name="uuid" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
-    <elements>
-        <element name="CDProfile" positionX="-63" positionY="-18" width="128" height="104"/>
-    </elements>
 </model>

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/ProfileMapper.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/ProfileMapper.swift
@@ -38,7 +38,7 @@ struct ProfileMapper: DTOMapper, ModelMapper {
     func toDTO(_ ws: Profile) throws -> CDProfile {
         let profile = ProfileHeaderMapper(context).toDTO(ws)
         do {
-            profile.json = try JSONEncoder().encode(ws)
+            profile.encryptedJSON = try JSONEncoder().encode(ws)
         } catch {
             assertionFailure("Unable to encode profile: \(error)")
             throw error
@@ -47,7 +47,7 @@ struct ProfileMapper: DTOMapper, ModelMapper {
     }
 
     static func toModel(_ dto: CDProfile) throws -> Profile? {
-        guard let json = dto.json else {
+        guard let json = dto.encryptedJSON ?? dto.json else {
             Utils.assertCoreDataDecodingFailed()
             return nil
         }


### PR DESCRIPTION
Now possible with iOS 15 target, but from:

<https://developer.apple.com/documentation/cloudkit/encrypting_user_data>

> The encrypted fields can’t have indexes because the server can’t read the fields. The encrypted fields also have to be newly introduced to an existing record or a new record. You can’t convert existing unencrypted fields in the CloudKit schema.

Therefore it must be a new field. As to Core Data:

https://developer.apple.com/documentation/coredata/nsattributedescription/3746827-allowscloudencryption

> Set this property to true to store the attribute’s value in an encrypted form in iCloud. Only use this property with new attributes. Core Data doesn’t support encrypting attributes that already exist in your CloudKit schema, or attributes that represent relationships between entities.

TL;DR Add new `encryptedJSON` field with fallback to `json`.

Going forward, persist profiles encrypted to the CloudKit container. Conversely, read from the encrypted field if any, falling back to the plain JSON field. This is a requirement until full migration is implemented.

**WARNING: the change is NOT backward compatible, as it would defeat the purpose. That is, once the profile is stored encrypted, the old plain profile is erased and its content won't be readable by older versions of the app.**