### PR TITLE
Regression in purchase elegibility predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Regression in purchase elegibility predicate. [#460](https://github.com/passepartoutvpn/passepartout-apple/pull/460)
+
 ## 2.3.1 (2024-01-06)
 
 ### Fixed

--- a/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
@@ -219,11 +219,11 @@ extension ProductManager {
 
 extension ProductManager {
     func isActivePurchase(_ feature: LocalProduct) -> Bool {
-        purchasedFeatures.contains(feature) && cancelledPurchases?.contains(feature) == false
+        purchasedFeatures.contains(feature) && cancelledPurchases?.contains(feature) != true
     }
 
     func isActivePurchase(where predicate: (LocalProduct) -> Bool) -> Bool {
-        purchasedFeatures.contains(where: predicate) && cancelledPurchases?.contains(where: predicate) == false
+        purchasedFeatures.contains(where: predicate) && cancelledPurchases?.contains(where: predicate) != true
     }
 
     func isCurrentPlatformVersion() -> Bool {


### PR DESCRIPTION
The cancellation predicate does not include the condition where cancelled purchases is nil.