### PR TITLE
Rewrite wrong refund logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- "Restore purchases" not working. [#459](https://github.com/passepartoutvpn/passepartout-apple/issues/459)
+- Purchase is not credited if any refund was issued in the past. [#461](https://github.com/passepartoutvpn/passepartout-apple/issues/461)
+
 ## 2.3.2 (2024-01-09)
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   dotenv

--- a/Passepartout/App/Constants/Constants+App.swift
+++ b/Passepartout/App/Constants/Constants+App.swift
@@ -163,10 +163,11 @@ extension Constants {
         private static let parentPath = "Library/Caches"
 
         static let level: LoggerLevel = {
-            guard let levelString = ProcessInfo.processInfo.environment["LOG_LEVEL"], let levelNum = Int(levelString) else {
-                return .info
+            guard let levelString = ProcessInfo.processInfo.environment["LOG_LEVEL"],
+                  let levelNum = Int(levelString) else {
+                return .debug
             }
-            return .init(rawValue: levelNum) ?? .info
+            return .init(rawValue: levelNum) ?? .debug
         }()
 
         static let maxBytes = 100000

--- a/Passepartout/App/Context/AppContext.swift
+++ b/Passepartout/App/Context/AppContext.swift
@@ -122,15 +122,6 @@ private extension AppContext {
                     self?.reviewer.reportEvent()
                 }
             }.store(in: &cancellables)
-
-        productManager.didRefundProducts
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                Task {
-                    pp_log.info("Refunds detected, uninstalling VPN profile")
-                    await self?.coreContext.vpnManager.uninstall()
-                }
-            }.store(in: &cancellables)
     }
 
     // eligibility: ignore network settings if ineligible

--- a/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
@@ -194,15 +194,25 @@ public final class ProductManager: NSObject, ObservableObject {
 
 extension ProductManager {
     public func isEligible(forFeature feature: LocalProduct) -> Bool {
-        if let purchasedAppBuild = purchasedAppBuild {
+        if let purchasedAppBuild {
             if feature == .networkSettings && buildProducts.hasProduct(.networkSettings, atBuild: purchasedAppBuild) {
                 return true
             }
         }
+        pp_log.verbose("Eligibility: purchasedFeatures = \(purchasedFeatures)")
+        pp_log.verbose("Eligibility: purchaseDates = \(purchaseDates)")
+        pp_log.verbose("Eligibility: cancelledPurchases = \(cancelledPurchases ?? [])")
+        pp_log.verbose("Eligibility: isIncludedInFullVersion(\(feature)) = \(isIncludedInFullVersion(feature))")
         if isIncludedInFullVersion(feature) {
-            return isFullVersion() || isActivePurchase(feature)
+            let isFullVersion = isFullVersion()
+            let isActive = isActivePurchase(feature)
+            pp_log.verbose("Eligibility: isFullVersion() = \(isFullVersion)")
+            pp_log.verbose("Eligibility: isActivePurchase(\(feature)) = \(isActive)")
+            return isFullVersion || isActive
         }
-        return isActivePurchase(feature)
+        let isActive = isActivePurchase(feature)
+        pp_log.verbose("Eligibility: isActivePurchase(\(feature)) = \(isActive)")
+        return isActive
     }
 
     public func isEligible(forProvider providerName: ProviderName) -> Bool {
@@ -236,11 +246,14 @@ extension ProductManager {
 
     public func isFullVersion() -> Bool {
         if appType == .fullVersion {
+            pp_log.verbose("Eligibility: appType = .fullVersion")
             return true
         }
+        pp_log.verbose("Eligibility: isCurrentPlatformVersion() = \(isCurrentPlatformVersion())")
         if isCurrentPlatformVersion() {
             return true
         }
+        pp_log.verbose("Eligibility: isActivePurchase(.fullVersion) = \(isActivePurchase(.fullVersion))")
         return isActivePurchase(.fullVersion)
     }
 


### PR DESCRIPTION
According to [Apple](https://developer.apple.com/documentation/appstorereceipts/cancellation_date_ms) and [Kvitto](https://github.com/Cocoanetics/Kvitto/blob/052ee7ffdb218199188916f92c638e857fe5b1b4/Core/Source/InAppPurchaseReceipt.swift#L71) documentation, any receipt with a cancellation date should be discarded.

The app has always had this logic wrong, but it only revealed the issue after adding `cancelledPurchases.contains()` to the feature eligibility condition:

https://github.com/passepartoutvpn/passepartout-apple/blob/821d4c79f43c1bbad30d4611fba25c409dabebc9/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift#L222

So, if both a purchase and a refund of feature `.foobar` existed, whatever the dates, the purchase was incorrectly discarded.

Fixes #459, fixes #461 