### PR TITLE
On-demand not applying to wired connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - "Restore purchases" not working. [#459](https://github.com/passepartoutvpn/passepartout-apple/issues/459)
 - Purchase is not credited if any refund was issued in the past. [#461](https://github.com/passepartoutvpn/passepartout-apple/issues/461)
+- On-demand not applying to wired connections. [#463](https://github.com/passepartoutvpn/passepartout-apple/pull/463)
 
 ## 2.3.2 (2024-01-10)
 

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/OnDemand+Rules.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/OnDemand+Rules.swift
@@ -81,6 +81,11 @@ private extension Profile.OnDemand {
         // IMPORTANT: append fallback rule last
         rules.append(globalRule())
 
+        pp_log.debug("On-demand rules:")
+        rules.forEach {
+            pp_log.debug("\($0)")
+        }
+
         return rules
     }
 }

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/OnDemand+Rules.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Extensions/OnDemand+Rules.swift
@@ -63,7 +63,7 @@ private extension Profile.OnDemand {
                 rules.append(cellularRule())
             }
             #endif
-            #if os(macOS)
+            #if targetEnvironment(macCatalyst) || os(macOS)
             if Utils.hasEthernet() && withEthernetNetwork {
                 if let rule = ethernetRule() {
                     rules.append(rule)
@@ -123,7 +123,7 @@ private extension Profile.OnDemand {
     }
     #endif
 
-    #if os(macOS)
+    #if targetEnvironment(macCatalyst) || os(macOS)
     func ethernetRule() -> NEOnDemandRule? {
         guard let compatibleEthernet = NEOnDemandRuleInterfaceType.compatibleEthernet else {
             return nil


### PR DESCRIPTION
Condition is `#if os(macOS)`, but a Catalyst app is actually `os(iOS)`, so the code adding the Ethernet rule was being ignored.

Regression from a0da930d98. The context is misleading, as the accidental change is unrelated to the commit subject. Probably some bad rebase.