### PR TITLE
Unintended sensitive data in issue reports

### DIFF
--- a/Passepartout/App/Views/EndpointView+OpenVPN.swift
+++ b/Passepartout/App/Views/EndpointView+OpenVPN.swift
@@ -360,7 +360,7 @@ private extension ObservableProfile {
             if self.value.isProvider {
                 // readonly
             } else {
-                pp_log.debug("Saving OpenVPN configuration: \($0)")
+                pp_log.verbose("Saving OpenVPN configuration: \($0)")
                 self.value.hostOpenVPNSettings?.configuration = $0.build()
             }
         }

--- a/Passepartout/App/Views/EndpointView+WireGuard.swift
+++ b/Passepartout/App/Views/EndpointView+WireGuard.swift
@@ -150,7 +150,7 @@ private extension ObservableProfile {
             if self.value.isProvider {
                 // readonly
             } else {
-                pp_log.debug("Saving WireGuard configuration: \($0)")
+                pp_log.verbose("Saving WireGuard configuration: \($0)")
                 self.value.hostWireGuardSettings?.configuration = $0.build()
             }
         }

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/KeychainSecretRepository.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/KeychainSecretRepository.swift
@@ -68,10 +68,10 @@ extension KeychainSecretRepository {
             return
         }
         guard let list = list else {
-            pp_log.debug("Keychain items: none")
+            pp_log.verbose("Keychain items: none")
             return
         }
-        pp_log.debug("Keychain items: \(list)")
+        pp_log.verbose("Keychain items: \(list)")
     }
 
     public func removeAllPasswords(matching id: UUID) {


### PR DESCRIPTION
Increasing log level to `.debug` for troubleshooting some users' issues may have exposed (arguably to me only) details that must not be exposed in a report:

- Keychain items
- Client certificates