### PR TITLE
Drop deprecated .disconnectsIfNotMatching

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutVPN/Domain/Profile+OnDemand.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPN/Domain/Profile+OnDemand.swift
@@ -49,9 +49,6 @@ extension Profile {
 
         public var withOtherNetworks: Set<OtherNetwork> = []
 
-        @available(*, deprecated, message: "Drop field after releasing as optional to the App Store")
-        public var disconnectsIfNotMatching: Bool? = true
-
         public init() {
         }
     }

--- a/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/CDProfileRepository.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutVPNImpl/Strategies/CDProfileRepository.swift
@@ -61,12 +61,7 @@ final class CDProfileRepository: ProfileRepository {
             existing.forEach(context.delete)
 
             try profiles.forEach {
-
-                // FIXME: on demand, workaround to retain profiles on downgrade (field is required before 2.2.0)
-                var copy = $0
-                copy.onDemand.disconnectsIfNotMatching = true
-
-                _ = try ProfileMapper(context).toDTO(copy)
+                _ = try ProfileMapper(context).toDTO($0)
             }
             try context.save()
         } catch {


### PR DESCRIPTION
Unused since trusted networks was converted to on-demand.