### PR TITLE
Improve some in-app tests

### DIFF
--- a/PassepartoutLibrary/Sources/PassepartoutFrontend/Domain/AppType.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutFrontend/Domain/AppType.swift
@@ -34,6 +34,8 @@ public enum AppType: Int {
 
     case fullVersion = 2
 
+    case fullVersionPlusTV = 3
+
     public var isRestricted: Bool {
         switch self {
         case .undefined, .beta:

--- a/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
@@ -59,10 +59,10 @@ public final class ProductManager: NSObject, ObservableObject {
     public init(inApp: any LocalInApp,
                 receiptReader: ReceiptReader,
                 overriddenAppType: AppType? = nil,
-                buildProducts: BuildProducts) {
+                buildProducts: BuildProducts? = nil) {
         self.overriddenAppType = overriddenAppType
         self.receiptReader = receiptReader
-        self.buildProducts = buildProducts
+        self.buildProducts = buildProducts ?? BuildProducts { _ in [] }
         appType = .undefined
 
         products = []

--- a/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
@@ -63,7 +63,7 @@ public final class ProductManager: NSObject, ObservableObject {
         self.overriddenAppType = overriddenAppType
         self.receiptReader = receiptReader
         self.buildProducts = buildProducts ?? BuildProducts { _ in [] }
-        appType = .undefined
+        appType = overriddenAppType ?? .undefined
 
         products = []
         self.inApp = inApp

--- a/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
+++ b/PassepartoutLibrary/Sources/PassepartoutFrontend/Managers/ProductManager.swift
@@ -224,11 +224,17 @@ extension ProductManager {
     }
 
     func isIncludedInFullVersion(_ feature: LocalProduct) -> Bool {
-        !feature.isLegacyPlatformVersion && feature != .appleTV
+        switch appType {
+        case .fullVersionPlusTV:
+            return !feature.isLegacyPlatformVersion
+
+        default:
+            return !feature.isLegacyPlatformVersion && feature != .appleTV
+        }
     }
 
     public func isFullVersion() -> Bool {
-        if appType == .fullVersion {
+        if appType == .fullVersion || appType == .fullVersionPlusTV {
             pp_log.verbose("Eligibility: appType = .fullVersion")
             return true
         }

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -123,11 +123,13 @@ final class ProductManagerTests: XCTestCase {
         let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertTrue(sut.isFullVersion())
-        XCTAssertTrue(LocalProduct
-            .allFeatures
-            .filter { $0 != .appleTV && !$0.isLegacyPlatformVersion }
-            .allSatisfy(sut.isEligible(forFeature:))
-        )
+        LocalProduct.allFeatures.forEach {
+            guard $0 != .appleTV && !$0.isLegacyPlatformVersion else {
+                XCTAssertFalse(sut.isEligible(forFeature: $0))
+                return
+            }
+            XCTAssertTrue(sut.isEligible(forFeature: $0))
+        }
     }
 
     func test_givenFullVersion_thenIsNotEligibleForAppleTV() {
@@ -251,6 +253,7 @@ final class ProductManagerTests: XCTestCase {
 
         LocalProduct.allFeatures.forEach {
             guard !$0.isLegacyPlatformVersion, $0 != .appleTV else {
+                XCTAssertFalse(sut.isEligible(forFeature: $0), "\($0)")
                 return
             }
             XCTAssertTrue(sut.isEligible(forFeature: $0), "\($0)")
@@ -263,6 +266,7 @@ final class ProductManagerTests: XCTestCase {
 
         LocalProduct.allFeatures.forEach {
             guard !$0.isLegacyPlatformVersion else {
+                XCTAssertFalse(sut.isEligible(forFeature: $0), "\($0)")
                 return
             }
             XCTAssertTrue(sut.isEligible(forFeature: $0), "\($0)")

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -125,10 +125,10 @@ final class ProductManagerTests: XCTestCase {
         XCTAssertTrue(sut.isFullVersion())
         LocalProduct.allFeatures.forEach {
             guard $0 != .appleTV && !$0.isLegacyPlatformVersion else {
-                XCTAssertFalse(sut.isEligible(forFeature: $0))
+                XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
                 return
             }
-            XCTAssertTrue(sut.isEligible(forFeature: $0))
+            XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
         }
     }
 
@@ -253,10 +253,10 @@ final class ProductManagerTests: XCTestCase {
 
         LocalProduct.allFeatures.forEach {
             guard !$0.isLegacyPlatformVersion, $0 != .appleTV else {
-                XCTAssertFalse(sut.isEligible(forFeature: $0), "\($0)")
+                XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
                 return
             }
-            XCTAssertTrue(sut.isEligible(forFeature: $0), "\($0)")
+            XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
         }
     }
 
@@ -266,10 +266,10 @@ final class ProductManagerTests: XCTestCase {
 
         LocalProduct.allFeatures.forEach {
             guard !$0.isLegacyPlatformVersion else {
-                XCTAssertFalse(sut.isEligible(forFeature: $0), "\($0)")
+                XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
                 return
             }
-            XCTAssertTrue(sut.isEligible(forFeature: $0), "\($0)")
+            XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
         }
     }
 }

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -123,13 +123,15 @@ final class ProductManagerTests: XCTestCase {
         let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertTrue(sut.isFullVersion())
-        LocalProduct.allFeatures.forEach {
-            guard $0 != .appleTV && !$0.isLegacyPlatformVersion else {
-                XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
-                return
+        LocalProduct
+            .allFeatures
+            .forEach {
+                guard $0 != .appleTV && !$0.isLegacyPlatformVersion else {
+                    XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
+                    return
+                }
+                XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
             }
-            XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
-        }
     }
 
     func test_givenFullVersion_thenIsNotEligibleForAppleTV() {
@@ -251,25 +253,29 @@ final class ProductManagerTests: XCTestCase {
         let reader = MockReceiptReader()
         let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .fullVersion)
 
-        LocalProduct.allFeatures.forEach {
-            guard !$0.isLegacyPlatformVersion, $0 != .appleTV else {
-                XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
-                return
+        LocalProduct
+            .allFeatures
+            .forEach {
+                guard !$0.isLegacyPlatformVersion, $0 != .appleTV else {
+                    XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
+                    return
+                }
+                XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
             }
-            XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
-        }
     }
 
     func test_givenFullPlusTVApp_thenIsEligibleForEveryFeature() {
         let reader = MockReceiptReader()
         let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .fullVersionPlusTV)
 
-        LocalProduct.allFeatures.forEach {
-            guard !$0.isLegacyPlatformVersion else {
-                XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
-                return
+        LocalProduct
+            .allFeatures
+            .forEach {
+                guard !$0.isLegacyPlatformVersion else {
+                    XCTAssertFalse(sut.isEligible(forFeature: $0), $0.rawValue)
+                    return
+                }
+                XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
             }
-            XCTAssertTrue(sut.isEligible(forFeature: $0), $0.rawValue)
-        }
     }
 }

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -138,9 +138,9 @@ final class ProductManagerTests: XCTestCase {
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertFalse(sut.isFullVersion())
-        XCTAssertFalse(LocalProduct
+        XCTAssertTrue(LocalProduct
             .allFeatures
-            .allSatisfy(sut.isEligible(forFeature:))
+            .allSatisfy { !sut.isEligible(forFeature: $0) }
         )
     }
 

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -31,8 +31,6 @@ import XCTest
 final class ProductManagerTests: XCTestCase {
     private let inApp = MockInApp()
 
-    private let noBuildProducts = BuildProducts { _ in [] }
-
     private let olderBuildNumber = 500
 
     private let defaultBuildNumber = 1000
@@ -69,7 +67,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenPurchase_whenReload_thenCredited() {
         let reader = MockReceiptReader()
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertFalse(sut.isEligible(forFeature: .fullVersion))
 
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
@@ -82,7 +80,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenPurchase_whenCancelled_thenRevoke() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertTrue(sut.isEligible(forFeature: .fullVersion))
 
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion], cancelledProducts: [.fullVersion])
@@ -95,7 +93,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenFeature_thenIsOnlyEligibleForFeature() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.siriShortcuts, .networkSettings])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertTrue(sut.isEligible(forFeature: .siriShortcuts))
         XCTAssertTrue(sut.isEligible(forFeature: .networkSettings))
@@ -106,7 +104,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenPlatformVersion_thenIsFullVersionForPlatform() {
         let reader = MockReceiptReader()
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
 #if targetEnvironment(macCatalyst)
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_macOS, .networkSettings])
@@ -128,7 +126,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenFullVersion_thenIsEligibleForAnyFeatureExceptAppleTV() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertTrue(sut.isFullVersion())
         XCTAssertTrue(LocalProduct
@@ -141,7 +139,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenFreeVersion_thenIsNotEligibleForAnyFeature() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertFalse(sut.isFullVersion())
         XCTAssertTrue(LocalProduct
@@ -153,7 +151,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenFreeVersion_thenIsNotEligibleForAppleTV() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertFalse(sut.isEligible(forFeature: .appleTV))
     }
@@ -161,7 +159,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenFullVersion_thenIsNotEligibleForAppleTV() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertFalse(sut.isEligible(forFeature: .appleTV))
     }
@@ -169,7 +167,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenAppleTV_thenIsEligibleForAppleTV() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.appleTV])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertTrue(sut.isEligible(forFeature: .appleTV))
     }
@@ -179,7 +177,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenNoPurchase_thenCanBuyFullAndPlatformVersion() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
 #if targetEnvironment(macCatalyst)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [.fullVersion, .fullVersion_macOS])
@@ -192,7 +190,7 @@ final class ProductManagerTests: XCTestCase {
         let reader = MockReceiptReader()
 
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [])
     }
 
@@ -201,11 +199,11 @@ final class ProductManagerTests: XCTestCase {
 
 #if targetEnvironment(macCatalyst)
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_macOS])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [])
 #else
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_iOS])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [])
 #endif
     }
@@ -215,11 +213,11 @@ final class ProductManagerTests: XCTestCase {
 
 #if targetEnvironment(macCatalyst)
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_iOS])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [.fullVersion_macOS])
 #else
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_macOS])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [.fullVersion_iOS])
 #endif
     }
@@ -227,7 +225,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenAppleTV_whenDidNotPurchase_thenCanPurchase() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertEqual(sut.purchasableProducts(withFeature: .appleTV), [.appleTV])
     }
@@ -235,7 +233,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenAppleTV_whenDidPurchase_thenCannotPurchase() {
         let reader = MockReceiptReader()
         reader.setReceipt(withBuild: defaultBuildNumber, products: [.appleTV])
-        let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
+        let sut = ProductManager(inApp: inApp, receiptReader: reader)
 
         XCTAssertEqual(sut.purchasableProducts(withFeature: .appleTV), [])
     }

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -232,4 +232,40 @@ final class ProductManagerTests: XCTestCase {
 
         XCTAssertEqual(sut.purchasableProducts(withFeature: .appleTV), [])
     }
+
+    // MARK: App type
+
+    func test_givenBetaApp_thenIsNotEligibleForAnyFeature() {
+        let reader = MockReceiptReader()
+        let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .beta)
+
+        XCTAssertTrue(LocalProduct
+            .allFeatures
+            .allSatisfy { !sut.isEligible(forFeature: $0) }
+        )
+    }
+
+    func test_givenFullApp_thenIsEligibleForEveryFeatureExceptAppleTV() {
+        let reader = MockReceiptReader()
+        let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .fullVersion)
+
+        LocalProduct.allFeatures.forEach {
+            guard !$0.isLegacyPlatformVersion, $0 != .appleTV else {
+                return
+            }
+            XCTAssertTrue(sut.isEligible(forFeature: $0), "\($0)")
+        }
+    }
+
+    func test_givenFullPlusTVApp_thenIsEligibleForEveryFeature() {
+        let reader = MockReceiptReader()
+        let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .fullVersionPlusTV)
+
+        LocalProduct.allFeatures.forEach {
+            guard !$0.isLegacyPlatformVersion else {
+                return
+            }
+            XCTAssertTrue(sut.isEligible(forFeature: $0), "\($0)")
+        }
+    }
 }

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -33,13 +33,19 @@ final class ProductManagerTests: XCTestCase {
 
     private let noBuildProducts = BuildProducts { _ in [] }
 
+    private let olderBuildNumber = 500
+
+    private let defaultBuildNumber = 1000
+
+    private let newerBuildNumber = 1500
+
     // MARK: Build products
 
     func test_givenBuildProducts_whenOlder_thenFullVersion() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 500, products: [])
+        reader.setReceipt(withBuild: olderBuildNumber, products: [])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: BuildProducts { build in
-            if build <= 1000 {
+            if build <= self.defaultBuildNumber {
                 return [.fullVersion]
             }
             return []
@@ -49,9 +55,9 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenBuildProducts_whenNewer_thenFreeVersion() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [])
+        reader.setReceipt(withBuild: newerBuildNumber, products: [])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: BuildProducts { build in
-            if build <= 1000 {
+            if build <= self.defaultBuildNumber {
                 return [.fullVersion]
             }
             return []
@@ -66,7 +72,7 @@ final class ProductManagerTests: XCTestCase {
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertFalse(sut.isEligible(forFeature: .fullVersion))
 
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
         XCTAssertFalse(sut.isEligible(forFeature: .fullVersion))
 
         sut.reloadReceipt()
@@ -75,11 +81,11 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenPurchase_whenCancelled_thenRevoke() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertTrue(sut.isEligible(forFeature: .fullVersion))
 
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion], cancelledProducts: [.fullVersion])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion], cancelledProducts: [.fullVersion])
         XCTAssertTrue(sut.isEligible(forFeature: .fullVersion))
 
         sut.reloadReceipt()
@@ -88,7 +94,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenFeature_thenIsOnlyEligibleForFeature() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [.siriShortcuts, .networkSettings])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.siriShortcuts, .networkSettings])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertTrue(sut.isEligible(forFeature: .siriShortcuts))
@@ -103,12 +109,12 @@ final class ProductManagerTests: XCTestCase {
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
 #if targetEnvironment(macCatalyst)
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion_macOS, .networkSettings])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_macOS, .networkSettings])
         sut.reloadReceipt()
         XCTAssertFalse(sut.isEligible(forFeature: .fullVersion_iOS))
         XCTAssertTrue(sut.isEligible(forFeature: .fullVersion_macOS))
 #else
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion_iOS, .networkSettings])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_iOS, .networkSettings])
         sut.reloadReceipt()
         XCTAssertTrue(sut.isEligible(forFeature: .fullVersion_iOS))
         XCTAssertFalse(sut.isEligible(forFeature: .fullVersion_macOS))
@@ -121,7 +127,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenFullVersion_thenIsEligibleForAnyFeatureExceptAppleTV() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertTrue(sut.isFullVersion())
@@ -134,7 +140,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenFreeVersion_thenIsNotEligibleForAnyFeature() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertFalse(sut.isFullVersion())
@@ -146,7 +152,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenFreeVersion_thenIsNotEligibleForAppleTV() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertFalse(sut.isEligible(forFeature: .appleTV))
@@ -154,7 +160,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenFullVersion_thenIsNotEligibleForAppleTV() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertFalse(sut.isEligible(forFeature: .appleTV))
@@ -162,7 +168,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenAppleTV_thenIsEligibleForAppleTV() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [.appleTV])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.appleTV])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertTrue(sut.isEligible(forFeature: .appleTV))
@@ -172,7 +178,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenNoPurchase_thenCanBuyFullAndPlatformVersion() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
 #if targetEnvironment(macCatalyst)
@@ -185,7 +191,7 @@ final class ProductManagerTests: XCTestCase {
     func test_givenFullVersion_thenCannotPurchase() {
         let reader = MockReceiptReader()
 
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [])
     }
@@ -194,11 +200,11 @@ final class ProductManagerTests: XCTestCase {
         let reader = MockReceiptReader()
 
 #if targetEnvironment(macCatalyst)
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion_macOS])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_macOS])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [])
 #else
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion_iOS])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_iOS])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [])
 #endif
@@ -208,11 +214,11 @@ final class ProductManagerTests: XCTestCase {
         let reader = MockReceiptReader()
 
 #if targetEnvironment(macCatalyst)
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion_iOS])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_iOS])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [.fullVersion_macOS])
 #else
-        reader.setReceipt(withBuild: 1500, products: [.fullVersion_macOS])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.fullVersion_macOS])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
         XCTAssertEqual(sut.purchasableProducts(withFeature: nil), [.fullVersion_iOS])
 #endif
@@ -220,7 +226,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenAppleTV_whenDidNotPurchase_thenCanPurchase() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertEqual(sut.purchasableProducts(withFeature: .appleTV), [.appleTV])
@@ -228,7 +234,7 @@ final class ProductManagerTests: XCTestCase {
 
     func test_givenAppleTV_whenDidPurchase_thenCannotPurchase() {
         let reader = MockReceiptReader()
-        reader.setReceipt(withBuild: 1500, products: [.appleTV])
+        reader.setReceipt(withBuild: defaultBuildNumber, products: [.appleTV])
         let sut = ProductManager(inApp: inApp, receiptReader: reader, buildProducts: noBuildProducts)
 
         XCTAssertEqual(sut.purchasableProducts(withFeature: .appleTV), [])

--- a/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
+++ b/PassepartoutLibrary/Tests/PassepartoutFrontendTests/ProductManagerTests.swift
@@ -249,7 +249,7 @@ final class ProductManagerTests: XCTestCase {
         )
     }
 
-    func test_givenFullApp_thenIsEligibleForEveryFeatureExceptAppleTV() {
+    func test_givenFullApp_thenIsEligibleForAnyFeatureExceptAppleTV() {
         let reader = MockReceiptReader()
         let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .fullVersion)
 
@@ -264,7 +264,7 @@ final class ProductManagerTests: XCTestCase {
             }
     }
 
-    func test_givenFullPlusTVApp_thenIsEligibleForEveryFeature() {
+    func test_givenFullPlusTVApp_thenIsEligibleForAnyFeature() {
         let reader = MockReceiptReader()
         let sut = ProductManager(inApp: inApp, receiptReader: reader, overriddenAppType: .fullVersionPlusTV)
 


### PR DESCRIPTION
A few things:

- One feature eligibility test was incorrect, namely `test_givenFreeVersion_thenIsNotEligibleForAnyFeature`
- Eligibility tests of feature subsets must also assert ineligibility of excluded features
- App type was not covered

Also add and test a new .fullVersionPlusTV app type including the .appleTV feature.